### PR TITLE
GIT_TOKEN -> GH_PAT in whole project

### DIFF
--- a/.github/workflows/render-leanpub.yml
+++ b/.github/workflows/render-leanpub.yml
@@ -27,7 +27,7 @@ jobs:
           # get the full repo
           fetch-depth: 0
           # use github PAT
-          token: ${{ secrets.GIT_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
 
 #      # Run leanbuild checks
 #      - name: Run leanbuild checks

--- a/getting_started.md
+++ b/getting_started.md
@@ -70,7 +70,7 @@ jobs:
 ```
 
 Change the `repository:` line to have the name of this new Leanpub repository.
-Note if you haven't set a [GIT_TOKEN git secret](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/blob/main/getting_started.md#set-up-github-secrets) and you are not a part of `jhudsl` organization, you will need to set that by following the instructions linked in the _Bookdown repository's getting_started.md.
+Note if you haven't set a [GH_PAT git secret](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/blob/main/getting_started.md#set-up-github-secrets) and you are not a part of `jhudsl` organization, you will need to set that by following the instructions linked in the _Bookdown repository's getting_started.md.
 
 Optionally/Recommended -- if you would like to have PRs filed _automatically_ when you make changes to your _Bookdown repository, you will need to uncomment this section at the top of the file:
 


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
Should fix this error: https://github.com/jhudsl/DaSL_Course_Template_Leanpub/actions/runs/1174260462

Because of sync GHA requirements, we have to use GH_PAT instead of GIT_TOKEN: https://github.com/jhudsl/DaSL_Course_Template_Bookdown/issues/146#issuecomment-906820219

But I forgot to update that in this repo.